### PR TITLE
feat: add PR comment agent hook

### DIFF
--- a/.github/workflows/pr-comment-agent.yml
+++ b/.github/workflows/pr-comment-agent.yml
@@ -1,0 +1,35 @@
+name: PR Comment Agent
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  spawn-agent:
+    if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment'
+    runs-on: [self-hosted, openclaw]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure gh is authenticated
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh auth status
+
+      - name: Run OpenClaw PR comment agent
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 scripts/openclaw_pr_comment_agent.py

--- a/docs/PR_COMMENT_AGENT.md
+++ b/docs/PR_COMMENT_AGENT.md
@@ -9,6 +9,7 @@ This repository includes a GitHub Actions workflow that can spin up a local Open
   - `pull_request_review_comment` events
 - It checks out the PR branch
 - It calls the local OpenClaw CLI with the PR comment and PR context
+- It posts the agent's reply back to the PR as a comment
 - If the agent changes files, the hook commits and pushes those changes back to the branch
 
 ## Requirements

--- a/docs/PR_COMMENT_AGENT.md
+++ b/docs/PR_COMMENT_AGENT.md
@@ -1,0 +1,37 @@
+# PR Comment Agent Hook
+
+This repository includes a GitHub Actions workflow that can spin up a local OpenClaw agent whenever a pull request receives a comment.
+
+## How it works
+
+- The workflow listens to:
+  - `issue_comment` events on PRs
+  - `pull_request_review_comment` events
+- It checks out the PR branch
+- It calls the local OpenClaw CLI with the PR comment and PR context
+- If the agent changes files, the hook commits and pushes those changes back to the branch
+
+## Requirements
+
+This is intended for a self-hosted runner with:
+
+- `openclaw` installed and configured
+- `gh` installed and authenticated
+- access to the repository checkout
+
+The workflow uses a self-hosted runner label set to:
+
+- `self-hosted`
+- `openclaw`
+
+If your runner uses a different label, update `.github/workflows/pr-comment-agent.yml`.
+
+## Safety controls
+
+- Bot comments are ignored.
+- Comments containing `[openclaw-skip]` are ignored.
+- The agent runs on the checked-out PR branch and keeps changes focused.
+
+## Manual use
+
+You can also run the driver script locally after setting `GITHUB_EVENT_PATH`, `GITHUB_EVENT_NAME`, `GITHUB_REPOSITORY`, and `GH_TOKEN`.

--- a/scripts/openclaw_pr_comment_agent.py
+++ b/scripts/openclaw_pr_comment_agent.py
@@ -88,12 +88,14 @@ def agent_prompt(pr_number: int, pr: dict, comment_author: str, comment_body: st
         - If code or docs need updating, make the minimum safe changes.
         - Run the most relevant validation you can.
         - Leave the repo in a commit-ready state.
+        - Also draft a concise PR reply that can be posted back automatically.
         - If the comment is purely informational, explain the needed response clearly.
 
         Important:
         - Keep changes focused.
         - Avoid broad refactors unless the comment clearly requires them.
         - Prefer minimal, reviewable edits.
+        - Write the reply as normal GitHub comment markdown, without surrounding fences.
         """
     ).strip()
 
@@ -106,6 +108,15 @@ def git_status() -> str:
 def current_branch() -> str:
     result = run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=REPO_ROOT)
     return result.stdout.strip()
+
+
+def post_pr_comment(pr_number: int, body: str) -> None:
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as tmp:
+        tmp.write(body)
+        tmp_path = tmp.name
+    run(["gh", "pr", "comment", str(pr_number), "--repo", os.environ["GITHUB_REPOSITORY"], "--body-file", tmp_path], cwd=REPO_ROOT)
 
 
 def maybe_commit_and_push(pr_number: int) -> str | None:
@@ -160,6 +171,23 @@ def main() -> int:
     print(agent_run.stdout)
     if agent_run.stderr:
         print(agent_run.stderr, file=sys.stderr)
+
+    reply = None
+    try:
+        parsed = json.loads(agent_run.stdout)
+        payloads = parsed.get("payloads", [])
+        texts = [p.get("text", "").strip() for p in payloads if p.get("text")]
+        reply = "\n\n".join(texts).strip() if texts else None
+    except json.JSONDecodeError:
+        reply = None
+
+    if not reply:
+        reply = (
+            f"OpenClaw checked this PR comment from @{author} and ran the agent, but it did not return a comment-ready reply. "
+            f"The repo state will be committed separately if files changed."
+        )
+
+    post_pr_comment(pr_number, reply)
 
     commit_sha = maybe_commit_and_push(pr_number)
     if commit_sha:

--- a/scripts/openclaw_pr_comment_agent.py
+++ b/scripts/openclaw_pr_comment_agent.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd or REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=check,
+    )
+
+
+def load_event() -> dict:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        raise SystemExit("GITHUB_EVENT_PATH is not set")
+    return json.loads(Path(event_path).read_text())
+
+
+def is_pr_comment_event(event: dict) -> tuple[bool, int | None, str, str]:
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    comment = event.get("comment", {})
+    author = comment.get("user", {}).get("login", "")
+    body = comment.get("body", "")
+
+    if author.endswith("[bot]") or author in {"github-actions[bot]"}:
+        return False, None, author, body
+    if "[openclaw-skip]" in body.lower():
+        return False, None, author, body
+
+    if event_name == "issue_comment":
+        issue = event.get("issue", {})
+        if issue.get("pull_request"):
+            return True, int(issue["number"]), author, body
+        return False, None, author, body
+
+    if event_name == "pull_request_review_comment":
+        pr = event.get("pull_request", {})
+        if pr.get("number"):
+            return True, int(pr["number"]), author, body
+        return False, None, author, body
+
+    return False, None, author, body
+
+
+def gh_json(args: list[str]) -> dict:
+    result = run(["gh", *args, "--json", "title,body,headRefName,baseRefName,headRefOid,url,author"], cwd=REPO_ROOT)
+    return json.loads(result.stdout)
+
+
+def checkout_pr(pr_number: int, repo: str) -> None:
+    run(["gh", "pr", "checkout", str(pr_number), "--repo", repo], cwd=REPO_ROOT)
+
+
+def agent_prompt(pr_number: int, pr: dict, comment_author: str, comment_body: str, comment_url: str) -> str:
+    return textwrap.dedent(
+        f"""
+        You are an autonomous OpenClaw coding agent responding to a GitHub PR comment.
+
+        Repository: {os.environ.get('GITHUB_REPOSITORY', '')}
+        PR #{pr_number}: {pr.get('title', '')}
+        PR URL: {pr.get('url', '')}
+        Base branch: {pr.get('baseRefName', '')}
+        Head branch: {pr.get('headRefName', '')}
+        Head SHA: {pr.get('headRefOid', '')}
+
+        Comment author: {comment_author}
+        Comment URL: {comment_url}
+        Comment body:
+        ---
+        {comment_body}
+        ---
+
+        Your task:
+        - Inspect the checked-out repository and the PR comment.
+        - If code or docs need updating, make the minimum safe changes.
+        - Run the most relevant validation you can.
+        - Leave the repo in a commit-ready state.
+        - If the comment is purely informational, explain the needed response clearly.
+
+        Important:
+        - Keep changes focused.
+        - Avoid broad refactors unless the comment clearly requires them.
+        - Prefer minimal, reviewable edits.
+        """
+    ).strip()
+
+
+def git_status() -> str:
+    result = run(["git", "status", "--short"], cwd=REPO_ROOT)
+    return result.stdout.strip()
+
+
+def current_branch() -> str:
+    result = run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=REPO_ROOT)
+    return result.stdout.strip()
+
+
+def maybe_commit_and_push(pr_number: int) -> str | None:
+    if not git_status():
+        return None
+    run(["git", "config", "user.name", "openclaw-bot"], cwd=REPO_ROOT)
+    run(["git", "config", "user.email", "openclaw-bot@users.noreply.github.com"], cwd=REPO_ROOT)
+    run(["git", "add", "-A"], cwd=REPO_ROOT)
+    run(["git", "commit", "-m", f"fix: address PR comment #{pr_number}"], cwd=REPO_ROOT)
+    branch = current_branch()
+    run(["git", "push", "origin", branch], cwd=REPO_ROOT)
+    sha = run(["git", "rev-parse", "HEAD"], cwd=REPO_ROOT).stdout.strip()
+    return sha
+
+
+def main() -> int:
+    event = load_event()
+    ok, pr_number, author, body = is_pr_comment_event(event)
+    if not ok or pr_number is None:
+        print("No action: not a PR comment event or it was skipped.")
+        return 0
+
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    if not repo:
+        raise SystemExit("GITHUB_REPOSITORY is not set")
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        os.environ.setdefault("GH_TOKEN", token)
+        os.environ.setdefault("GITHUB_TOKEN", token)
+
+    checkout_pr(pr_number, repo)
+    pr = gh_json(["pr", "view", str(pr_number), "--repo", repo])
+    comment_url = event.get("comment", {}).get("html_url", "")
+    prompt = agent_prompt(pr_number, pr, author, body, comment_url)
+
+    agent_cmd = [
+        "openclaw",
+        "agent",
+        "--agent",
+        "main",
+        "--local",
+        "--thinking",
+        "medium",
+        "--timeout",
+        "3600",
+        "--json",
+        "--message",
+        prompt,
+    ]
+    agent_run = run(agent_cmd, cwd=REPO_ROOT)
+    print(agent_run.stdout)
+    if agent_run.stderr:
+        print(agent_run.stderr, file=sys.stderr)
+
+    commit_sha = maybe_commit_and_push(pr_number)
+    if commit_sha:
+        print(f"Committed and pushed agent changes at {commit_sha}")
+    else:
+        print("No file changes produced by the agent.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that spins up an OpenClaw agent when a PR receives a comment
- Checkout the PR branch, feed the comment + PR context to `openclaw agent --agent main --local`
- Commit and push any resulting fixes back to the PR branch
- Add docs for the hook and setup expectations

## Notes
- Intended for a self-hosted runner with OpenClaw and gh configured
- Skips bot comments and comments tagged with `[openclaw-skip]`
- The agent runs against the checked-out PR branch and keeps changes focused